### PR TITLE
Added option to give 'startList()' a CSS class that is added to the table class.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -175,7 +175,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin {
     /**
      * Sets the list header
      */
-    function startList() {
+    function startList($callerClass=NULL) {
 
         // table style
         switch ($this->style) {
@@ -193,6 +193,9 @@ class helper_plugin_pagelist extends DokuWiki_Plugin {
         }
         
         if($class) {
+            if ($callerClass) {
+                $class .= ' '.$callerClass;
+            }
             $this->doc = '<div class="table">'.DOKU_LF.'<table class="'.$class.'">'.DOKU_LF;
         } else {
             // Simplelist is enabled; Skip header and firsthl


### PR DESCRIPTION
In that way the caller can add his own specific class for the whole table, e.g to alter the width of the whole table without affecting other pagelists.

I want to use this to add a class **plugin_task_tasklist** to pagelists created by the task plugin. In that way the tasklist plugin can assign a width to it's tasklists (pagelists) without changing the width of all pagelists tables.

As the new parameter for **startList()** is optional, the change is completely backwards compatible.