### PR TITLE
some improvements

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -472,14 +472,13 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             }
             $title .= ' />';
         } else {
-            if ($this->showfirsthl) {
+            //not overwrite titles in earlier provided data
+            if (!$this->page['title'] && $this->showfirsthl) {
                 $this->page['title'] = $this->getMeta('title');
-            } else {
-                $this->page['title'] = $id;
             }
 
             if (!$this->page['title']) {
-                $this->page['title'] = str_replace('_', ' ', noNS($id));
+                $this->page['title'] = str_replace('_', ' ', noNSorNS($id));
             }
             $title = hsc($this->page['title']);
         }


### PR DESCRIPTION
-fix handling of title setting Fixes #95 
-add modifyColumn() for en/disabling columns, setHeader() for replace heading cells. Alternative manner of #100 
-reset header array in constructor, and therefore also when table is
finished. Fixes #98 
-update phpdocs

#97 is fixed in simpler way, columns can be added or en/disabled. setHeader() let replace or extend column headings. Internally is not extra distinction is made between built-in or not.

Based on the work of @lpaulsen93 in #100, but in bit different manner.