### PR TITLE
Fix issue #150: undefined array key 'title' in helper.php on line 525.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -521,6 +521,9 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             }
             $title .= ' />';
         } else {
+            if (!isset($this->page['title'])) {
+                $this->page['title'] = "";
+            }
             //not overwrite titles in earlier provided data
             if (!$this->page['title'] && $this->showfirsthl) {
                 $this->page['title'] = $this->getMeta('title');


### PR DESCRIPTION
```
Undefined array key "title" in ../public_html/wiki/lib/plugins/pagelist/helper.php on line 525
```
* PHP 8.1
* DokuWiki 2023-04-04a "Jack Jackrum"
* Pagelist plugin 2022-11-13

This fix is harmless and should work on any version of PHP without breaking any installations.