### PR TITLE
allow sorting, the flag sortby=<columnname> sets which column is used for sorting

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -15,5 +15,4 @@ $conf['showimage']    = 0;
 $conf['showdiff']     = 0;
 $conf['sort']         = 0;
 $conf['rsort']        = 0;
-
-//Setup VIM: ex: et ts=2 :
+$conf['sortby']       = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -20,5 +20,4 @@ $meta['showimage']    = array('onoff');
 $meta['showdiff']     = array('onoff');
 $meta['sort']         = array('onoff');
 $meta['rsort']        = array('onoff');
-
-//Setup VIM: ex: et ts=2 :
+$meta['sortby']       = array('string', '_pattern' => '/^([^&=]*)$/');

--- a/helper.php
+++ b/helper.php
@@ -439,10 +439,25 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         if ($this->sortKey !== '') {
             $sortKey = $this->page[$this->sortKey] ?? false;
             if ($sortKey === false) {
+                //entry corresponding to sortKey is not yet set
                 if ($this->sortKey == "draft") {
                     $this->page['draft'] = $this->getMeta('type') == 'draft';
                 }
                 $this->getPageData($id);
+                if ($this->sortKey == "pagename") {
+                    $this->page['pagename'] = noNS($id);
+                }
+                if ($this->sortKey == "ns") {
+                    // sorts pages before namespaces using a zero byte
+                    // see https://github.com/dokufreaks/plugin-tag/commit/7df7f2cb315c5a3a21b9dfacae89bd3ee661c690
+                    $pos = strrpos($id, ':');
+                    if ($pos === false) {
+                        $sortkey = "\0".$id;
+                    } else {
+                        $sortkey = substr_replace($id, "\0\0", $pos, 1);
+                    }
+                    $this->page['ns'] = str_replace(':', "\0", $sortkey);
+                }
                 if ($this->sortKey == "date") {
                     $this->getDate();
                 }

--- a/helper.php
+++ b/helper.php
@@ -240,7 +240,6 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         if (!is_array($flags)) return false;
 
         foreach ($flags as $flag) {
-            echo ' '.$flag;
             switch ($flag) {
                 case 'default':
                     $this->style = 'default';

--- a/helper.php
+++ b/helper.php
@@ -351,7 +351,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
 
         if ($class) {
             if ($callerClass) {
-                $class .= ' ' . $callerClass;
+                $class .= ' plgn__pglist ' . $callerClass;
             }
             $this->doc = '<div class="table"><table class="' . $class . '">';
         } else {

--- a/helper.php
+++ b/helper.php
@@ -90,6 +90,11 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
     protected $tag = null;
 
     /**
+     * @var int limits the number of rows shown, 0 is all.
+     */
+    private $limit;
+
+    /**
      * Constructor gets default preferences
      *
      * These can be overriden by plugins using this class
@@ -126,6 +131,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         ];
 
         $this->header = [];
+        $this->limit = 0;
     }
 
     public function getMethods()
@@ -294,6 +300,9 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             //for plugins to propose a default value for the sortby flag
             if (substr($flag, 0, 14) == 'defaultsortby=') {
                 $this->defaultSortKey = substr($flag, 14);
+            }
+            if (substr($flag, 0, 6) == 'limit=') {
+                $this->limit = (int) substr($flag, 6);
             }
 
             /** @see $column array, enable/disable columns */
@@ -624,8 +633,14 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             }
         }
 
+        $cnt = 0;
         foreach ($this->pages as $page) {
             $this->renderPageRow($page);
+
+            $cnt++;
+            if($this->limit > 0 && $cnt >= $this->limit){
+                break;
+            }
         }
 
         if ($this->style != 'simplelist') {

--- a/helper.php
+++ b/helper.php
@@ -58,7 +58,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
     public $rsort = false;
 
     /**
-     * @var string the data entry to use as key for sorting
+     * @var string the item to use as key for sorting
      */
     private $sortKey;
     /**
@@ -101,6 +101,10 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         $this->showfirsthl = $this->getConf('showfirsthl'); //on-off
         $this->sort = $this->getConf('sort'); //on-off
         $this->rsort = $this->getConf('rsort'); //on-off
+        $this->sortKey = $this->getConf('sortby'); //string
+        if($this->sortKey) {
+            $this->sort = true;
+        }
 
         $this->plugins = [
             'discussion' => ['comments'],
@@ -122,7 +126,6 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         ];
 
         $this->header = [];
-        $this->sortKey = '';
     }
 
     public function getMethods()
@@ -288,6 +291,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
                 $this->sortKey = substr($flag, 7);
                 $this->sort = true;
             }
+            //for plugins to propose a default value for the sortby flag
             if (substr($flag, 0, 14) == 'defaultsortby=') {
                 $this->defaultSortKey = substr($flag, 14);
             }

--- a/helper.php
+++ b/helper.php
@@ -61,6 +61,10 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
      * @var string the data entry to use as key for sorting
      */
     private $sortKey;
+    /**
+     * @var string let plugins set their own default without already enabling sorting
+     */
+    private $defaultSortKey = 'id';
 
     /**
      * @var array with entries: 'pluginname' => ['columnname1', 'columnname2'], registers the available columns per plugin
@@ -236,6 +240,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         if (!is_array($flags)) return false;
 
         foreach ($flags as $flag) {
+            echo ' '.$flag;
             switch ($flag) {
                 case 'default':
                     $this->style = 'default';
@@ -284,6 +289,9 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
                 $this->sortKey = substr($flag, 7);
                 $this->sort = true;
             }
+            if (substr($flag, 0, 14) == 'defaultsortby=') {
+                $this->defaultSortKey = substr($flag, 14);
+            }
 
             /** @see $column array, enable/disable columns */
             if (substr($flag, 0, 2) == 'no') {
@@ -298,7 +306,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             }
         }
         if ($this->sortKey === '' && $this->sort) {
-            $this->sortKey = 'id';
+            $this->sortKey = $this->defaultSortKey;
         }
         return true;
     }

--- a/helper.php
+++ b/helper.php
@@ -688,7 +688,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
 
         // produce output
         $section = !empty($this->page['section']) ? '#' . $this->page['section'] : '';
-        $content = '<a href="' . wl($id) . $section . '" class="' . $class . '" title="' . $id . '">' . $title . '</a>';
+        $content = '<a href="' . wl($id) . $section . '" class="' . $class . '" title="' . $id . '"  data-wiki-id="' . $id . '">' . $title . '</a>';
         if ($this->style == 'list') {
             $content = '<ul><li>' . $content . '</li></ul>';
         }

--- a/helper.php
+++ b/helper.php
@@ -629,7 +629,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         if ($this->sort) {
             Sort::ksort($this->pages);
             if ($this->rsort) {
-                arsort($this->pages);
+                $this->pages = array_reverse($this->pages, true);
             }
         }
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -12,6 +12,6 @@ $lang['date']       = 'Date';
 $lang['user']       = 'User';
 $lang['desc']       = 'Description';
 $lang['diff']       = 'Differences';
+$lang['summary']    = 'Edit summery';
 $lang['diff_title'] = 'Show differences to current revisions';
 $lang['diff_alt']   = 'Show differences to current revisions';
-//Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,7 +5,7 @@
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Esther Brunner <wikidesign@gmail.com>
  */
- 
+
 // for the configuration manager
 $lang['style']            = 'Style of pagelist';
 $lang['style_o_default']  = 'default';
@@ -36,5 +36,4 @@ $lang['showimage']        = 'show image column (Pageimage Plugin needed)';
 $lang['showdiff']         = 'show link to the diff page';
 $lang['sort']             = 'sort pages by pagename';
 $lang['rsort']            = 'reverse sort pages by pagename';
-
-//Setup VIM: ex: et ts=2 :
+$lang['sortby']           = 'sort the page by the given item e.g. <code>id</code>, <code>pagename</code>, <code>ns</code>, <code>title</code>, <code>date</code>, <code>desc</code>, <code>user</code> etc or columns from plugins';

--- a/style.css
+++ b/style.css
@@ -25,7 +25,7 @@ div.dokuwiki table.ul td {
 }
 
 div.dokuwiki table.ul ul {
-  margin: 0 0 0 1.5em;
+  margin: 0 0 0 0;
 }
 
 div.dokuwiki table.pagelist th,

--- a/style.css
+++ b/style.css
@@ -1,3 +1,13 @@
+/* default three styles:
+ - table.plgn__pglist.pagelist (default)
+ - table.plgn__pglist.ul (list-option)
+ - table.plgn__pglist.inline (table-option: dokuwiki's table style)
+
+ extra class .plgn__pglist is always applied to table
+
+ Simple list is an default ul-li without class
+ */
+
 div.dokuwiki table.pagelist,
 div.dokuwiki table.ul {
   border: 0;
@@ -25,33 +35,23 @@ div.dokuwiki table.ul td {
 }
 
 div.dokuwiki table.ul ul {
-  margin: 0 0 0 0;
+  margin: 0;
 }
 
 div.dokuwiki table.pagelist th,
 div.dokuwiki table.ul th {
   background-color: __background_alt__;
+  color: __text_neu__;
+  font-size: 90%;
 }
 
-div.dokuwiki th.page,
-div.dokuwiki th.date,
-div.dokuwiki th.user,
-div.dokuwiki th.desc,
-div.dokuwiki th.comments,
-div.dokuwiki th.linkbacks,
-div.dokuwiki th.tags,
-div.dokuwiki th.diff,
-div.dokuwiki td.date,
-div.dokuwiki td.user,
-div.dokuwiki td.desc,
-div.dokuwiki td.comments,
-div.dokuwiki td.linkbacks,
-div.dokuwiki td.tags,
-div.dokuwiki td.diff {
+div.dokuwiki table.pagelist td,
+div.dokuwiki table.ul td {
   color: __text_neu__;
   font-size: 80%;
 }
 
-div.dokuwiki td.date {
-  text-align: left;
+div.dokuwiki table.pagelist td.page,
+div.dokuwiki table.ul td.page {
+  font-size: 100%;
 }

--- a/syntax.php
+++ b/syntax.php
@@ -121,17 +121,6 @@ class syntax_plugin_pagelist extends DokuWiki_Syntax_Plugin
             $pagelist->setFlags($flags);
             $pagelist->startList();
 
-            if ($pagelist->sort || $pagelist->rsort) {        // pages should be sorted by pagename
-                $fnc = function ($a, $b) {
-                    return strcmp(noNS($a["id"]), noNS($b["id"]));
-                };
-                usort($pages, $fnc);
-                // rsort is true - reverse sort the pages
-                if ($pagelist->rsort) {
-                    krsort($pages);
-                }
-            }
-
             foreach ($pages as $page) {
                 $pagelist->addPage($page);
             }


### PR DESCRIPTION
Replaces #152

- `sortby=<column>` enables sorting and set which column, for example:
   -  `id`, `date`, `desc`, `user`, `desc`, 
   -  or if plugins are installed: `comments`, `linkbacks`, `tags`, etc) 
   -  (I guess also works but some not that meaningful or some depending if you set them in the data array : `title`, `exists`, `draft`, `priority`, `file`, `section`, and other entries you actually filled in the `addPage([..]) ` array.)

- `sort` without sortby will sort with pageid `id` column,
- `nosort` disables(depends on order of flags, it might be overruled by the sortby)
- `rsort` reverses the sorting.

Sorting of non-existing pages might be annoying, these have a key that might sort higher than a lot of other keys. Now chosen to use a high number such that these are at least grouped.