### PR TITLE
Feature: add custom columns link to custom metadata of the page listed

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -16,3 +16,4 @@ $conf['showdiff']     = 0;
 $conf['sort']         = 0;
 $conf['rsort']        = 0;
 $conf['sortby']       = '';
+$conf['metaparentname'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -21,3 +21,4 @@ $meta['showimage']    = array('onoff');
 $meta['sort']         = array('onoff');
 $meta['rsort']        = array('onoff');
 $meta['sortby']       = array('string', '_pattern' => '/^([^&=]*)$/');
+$meta['metaparentname']  = array('string', '_pattern' => '/^([^&=]*)$/');

--- a/helper.php
+++ b/helper.php
@@ -107,6 +107,7 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         $this->sort = $this->getConf('sort'); //on-off
         $this->rsort = $this->getConf('rsort'); //on-off
         $this->sortKey = $this->getConf('sortby'); //string
+        $this->customCols = []; //Array to store custom cols configs
         if($this->sortKey) {
             $this->sort = true;
         }
@@ -318,6 +319,48 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             if (isset($this->column[$flag]) && $flag !== 'page') {
                 $this->column[$flag] = $value;
             }
+
+            /**
+             * Read params and set all custom cols configs
+             * 
+             * Declarative format:
+             * customcols=custommeta>datakey1,datakey2,>datakey3[%Y/%m/%d]
+             */
+            if (substr($flag, 0, 11) == 'customcols=') {
+                $colsDeclarations = explode(",", substr($flag, 11));
+
+                $lastMetaParentName = null;
+                foreach ($colsDeclarations as $index => $colDeclaration) {
+
+                    // Parse and set meta parent name
+                    $colDeclarationParse = explode(">", $colDeclaration);
+                    if (count($colDeclarationParse) == 1) {
+                        $colNameFormat = trim($colDeclarationParse[0]);
+                        $colMetaParentName = '';
+                    }
+                    elseif (count($colDeclarationParse) == 2) {
+                        $colNameFormat = trim($colDeclarationParse[1]);
+                        //Use last meta parent name if the current one is only set with ">"
+                        if (trim($colDeclarationParse[0]) == '' && $lastMetaParentName != null) {
+                            $colMetaParentName = $lastMetaParentName;
+                        } else {
+                            $colMetaParentName = $lastMetaParentName = trim($colDeclarationParse[0]);
+                        }
+                    }
+
+                    // Parse and set cols name and optional format
+                    $parseNameFormat = explode("[", $colNameFormat);
+                    $colName = trim($parseNameFormat[0]);
+                    $colFormat = null;
+                    if (count($parseNameFormat) == 2) {
+                        $colFormat = substr(trim($parseNameFormat[1]), 0, -1);
+                    }
+
+                    // Save col config
+                    $this->customCols[$index] = ['metaParentName' => $colMetaParentName,'name' => $colName,'format' => $colFormat];
+                    
+                }
+            }
         }
         if ($this->sortKey === '' && $this->sort) {
             $this->sortKey = $this->defaultSortKey;
@@ -408,6 +451,10 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
                     }
                 }
             }
+            //custom cols header
+            foreach ($this->customCols as $customCol) {
+                $this->doc .= '<th>' . ucfirst($customCol['name']) . '</th>';
+            }
             $this->doc .= '</tr>';
         }
         return true;
@@ -459,6 +506,10 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
             }
             if (!empty($this->column['summary'])) {
                 $this->getSummary();
+            }
+            // Get from page meta the custom col data
+            foreach ($this->customCols as $customCol) {
+                $this->getCustomColData($customCol);
             }
         }
 
@@ -581,6 +632,10 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
                     $this->printPluginCell($plugin, $col, $id);
                 }
             }
+        }
+        // Print custom col data
+        foreach ($this->customCols as $customCol) {
+            $this->printCustomCol($customCol);
         }
         $this->doc .= '</tr>';
     }
@@ -790,6 +845,13 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         return $empty;
     }
 
+    // Print custom col and apply optional format (datetime format)
+    protected function printCustomCol($customCol) {
+        if ($customCol['format']) {
+            return $this->printCell($customCol['name'], dformat($this->page[$customCol['name']], $customCol['format']));
+        }
+        return $this->printCell($customCol['name'], $this->page[$customCol['name']]);
+    }
 
     /**
      * Get default value for an unset element
@@ -987,4 +1049,20 @@ class helper_plugin_pagelist extends DokuWiki_Plugin
         return $sortKey;
     }
 
+    // Get metadata from page
+    private function getCustomColData($customCol) {
+        //In case if the data is inside of array (parent) in the metadata
+        if ($customCol['metaParentName']) {
+            if (array_key_exists($customCol['metaParentName'], $this->page)) return;
+            $customMetaArray = $this->getMeta($customCol['metaParentName']);
+
+            if (!isset($customMetaArray[$customCol['name']])) return;
+            $this->page[$customCol['name']] = $customMetaArray[$customCol['name']];
+        } 
+        //If the data is in the high lvl meta structure
+        else {
+            if (array_key_exists($customCol['name'], $this->page)) return;
+            $this->page[$customCol['name']] = $this->getMeta($customCol['name']);
+        }
+    }
 }


### PR DESCRIPTION
### **Motivation**
Currently, it is easy to create columns with the [standard metadata](https://www.dokuwiki.org/devel:metadata) used by DokuWiki or the metadata used by compatible plugins with pagelist (Blog, Tag...). But accessing custom metadata (in the .meta page file) and converting types for these data is not trivial. This feature is designed to be used in **combination** with another plugin I developed ([custom meta](https://www.dokuwiki.org/plugin:custommeta)) that allows adding custom metadata to pages. Using _pagelist_ and _custom meta_, it is possible to create highly customizable tables <3.

### **General**
This feature allows adding new columns to a table. Each column will be populated with values from the metadata of the listed page that match the column title. It is possible to access metadata values that are at the [first level](https://www.dokuwiki.org/devel:metadata) of the data structure (ex: creator) or within an array (ex: geo). This way, you can access both standard metadata, metadata from other plugins, and completely custom-stored metadata. The feature also includes the ability to transform UNIX timestamp data into a more user-friendly format.

### **Syntax**
New flag `customcols=`. Separated by commas, we indicate the name of the column to be added. This name must match the key that stores the value to be tabulated in the metadata. This name will be used as the header for the column.

`customcols=new_col_1,new_col_2`

If we want to convert a value stored as a UNIX timestamp in the metadata to a more user-friendly value, we can specify the desired format in "[ ]" after the column name. The converted value will be tabulated. NOTE: The format used to define the conversion is [strftime](https://www.php.net/strftime).

`customcols=my_date[%Y/%m/%d],new_col_2`

By default, the values of the keys are searched at the top level of the metadata structure. This means that we will generally access the standard metadata of DokuWiki in this way.

`customcols=title,creator`

If the key/value is located within an array in the metadata, it is possible to use ":" to prepend the name of the array.

`customcols=array_in_metadata:key_name`

It is possible to declare columns where their key/value pairs are stored in different arrays.

`customcols=plugin_a:key_name_1,my_array:key_name_2,date:modified[%Y/%m/%d]`

If we have many columns stored in the same array in the metadata, it can be cumbersome to repeat the name of the array over and over. It is possible to define the name of the array only when specifying the name of the first column. For the subsequent columns, you can add the ":" symbol at the beginning, and the last defined array to the left will be used automatically.

`customcols=my_meta_array:key_1,:key2,:key3`
(_key_2_ and _key_3_ will be searched within the last defined array to the left, in this case _my_meta_array_)

It is possible to "escape" and combine this rule to create combinations.

`customcols=my_meta_array:key_1,title,date:created[%Y/%m/%d],:modified[%Y/%m/%d],my_meta_array_2:key_2,:key_3`
(_key_1_ will be searched in _my_meta_array_. _title_ in the high level of the metadata. _created_ and _modified_ in the _date_ array.  _key_2_ and  _key_3_ in _my_meta_array_2_)

In cases where our use case always requires accessing the same array in the metadata to retrieve information (throughout the entire wiki), we can use the global configuration metaparentname to define the name of the array. This way, it will not be necessary to define it in each pagelist; by default, that array will be used to search for the information.

**Note**: Cases of arrays within arrays are not currently supported.

### **Implementation**
A three-stage parsing of "customcols=" is performed. Initially, the string is split by "," to organize the configurations for each column.

Next, it is divided by the ":" symbol. Here, it is determined whether the key of each column should be searched within an array or not, and whether that array was defined in this column or in one of the previous ones (inheritance rule from the left).

In the third stage, a division by "[" is performed to check if any column should be subjected to a conversion from UNIX to a more user-friendly time format.

All these configurations are stored for later use in `$this->customCols`

The key of each column is used to print the header (if the option is activated) in _startList()_.  The key of each column, along with its parent array (optional), is used to retrieve the information from the metadata in the function `getCustomColData()`. In this function, the global configuration for an array name is used if it is set. Each value of the column is printed in `printCustomCol()`. In this function, the UNIX conversion is performed if necessary.

Minor code modifications were made to add support for the global configuration of an metadata array name.



